### PR TITLE
Refactor LocalizedDateTimeFormatter to not use IntlDateFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ use Sunkan\Dictus\LocalizedFormat;
 use Sunkan\Dictus\LocalizedStrftimeFormatter;
 use Sunkan\Dictus\LocalizedDateTimeFormatter;
 
+LocalizedDateTimeFormatter::addLocaleFormat('sv_SE', new \Sunkan\Dictus\Locales\SvSe());
+
 $jsonDateFormatter = new DateTimeFormatter(DateTimeFormat::JSON);
 $localizedStrftimeFormatter = new LocalizedStrftimeFormatter('sv_SE', LocalizedFormat::DATETIME);
 $localizedDateTimeFormatter = new LocalizedDateTimeFormatter('sv_SE', 'l d F [kl.] H:i');
@@ -27,6 +29,65 @@ echo $jsonDateFormatter->format($date);
 echo $localizedStrftimeFormatterFormatter->format($date); // 21.08.2023 16:26
 echo $localizedDateTimeFormatter->format($date); // måndag 21 augusti kl. 16:26
 ```
+
+### Using localized formatters
+
+We recommend using `LocalizedDateTimeFormatter` that just support translating of 
+the regular [date format syntax](https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-parameters). 
+
+It will translate the following keys:
+
+* `D` short version of day name
+* `l` long version of day name
+* `M` short version of month name
+* `F` long version of month name
+
+It also supports 6 custom keys that helps with common localized formats
+
+Example for icelandic
+```php
+'LT'   => 'H:i',    // 17:32
+'LTS'  => 'H:i:s',  // 17:32:12
+'L'    => 'd.m.Y',  // 06.12.2023
+'LL'   => 'j. F Y', // 6. desember 2023
+'LLL'  => 'j. F [kl.] H:i',     // 6. desember kl. 17:32
+'LLLL' => 'l j. F Y [kl.] H:i', // miðvikudagur 6. desember 2023 kl. 17:32
+```
+
+#### Custom localization
+
+All you need to do to create your own localization is to create a class that's implements `LocaleFormat`
+
+```php
+
+final class CustomLocal implements \Sunkan\Dictus\LocaleFormat
+ {
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
+	{
+		return match ($char) {
+			'D' => 'short custom weekday name',
+			'l' => 'long custom weekday name',
+			'M' => null, // use english month names
+			'F' => null, // use english month names
+			default => null,
+		};
+	}
+
+	public function resolveFormat(string $format): ?string
+	{
+		return match($format) {
+			'LT' => 'H:i', // can be any valid date format string
+			'LTS' => 'H:i:s', // can be any valid date format string
+			'L' => 'd.m.Y', // can be any valid date format string
+			'LL' => 'j. F Y', // can be any valid date format string
+			'LLL' => 'j. F [kl.] H:i', // can be any valid date format string
+			'LLLL' => 'l j. F Y [kl.] H:i', // can be any valid date format string
+			default => null,
+		};
+	}
+}
+```
+
 ### Clock
 
 The library provides 3 clock implementations

--- a/src/LocaleFormat.php
+++ b/src/LocaleFormat.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus;
+
+interface LocaleFormat
+{
+	public function resolveFormat(string $format): ?string;
+
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string;
+}

--- a/src/Locales/EnGb.php
+++ b/src/Locales/EnGb.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus\Locales;
+
+use Sunkan\Dictus\LocaleFormat;
+
+final class EnGb implements LocaleFormat
+{
+	public function resolveFormat(string $format): ?string
+	{
+		return match($format) {
+			'LT' => 'H:i',
+			'LTS' => 'H:i:s',
+			'L' => 'd/m/Y',
+			'LL' => 'j F Y',
+			'LLL' => 'j F H:i',
+			'LLLL' => 'l, j F Y H:i',
+			default => null,
+		};
+	}
+
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
+	{
+		return null;
+	}
+}

--- a/src/Locales/IsIs.php
+++ b/src/Locales/IsIs.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus\Locales;
+
+use Sunkan\Dictus\LocaleFormat;
+
+final class IsIs implements LocaleFormat
+{
+	private const DAYS_SHORT = [
+		1 => 'mán',
+		2 => 'þri',
+		3 => 'mið',
+		4 => 'fim',
+		5 => 'fös',
+		6 => 'lau',
+		7 => 'sun',
+	];
+
+	private const DAYS_LONG = [
+		1 => 'mánudagur',
+		2 => 'þriðjudagur',
+		3 => 'miðvikudagur',
+		4 => 'fimmtudagur',
+		5 => 'föstudagur',
+		6 => 'laugardagur',
+		7 => 'sunnudagur',
+	];
+
+	private const MONTHS_SHORT = [
+		1 => 'jan',
+		2 => 'feb',
+		3 => 'mar',
+		4 => 'apr',
+		5 => 'maí',
+		6 => 'jún',
+		7 => 'júl',
+		8 => 'ágú',
+		9 => 'sep',
+		10 => 'okt',
+		11 => 'nóv',
+		12 => 'des',
+	];
+
+	private const MONTHS_LONG = [
+		1 => 'janúar',
+		2 => 'febrúar',
+		3 => 'mars',
+		4 => 'apríl',
+		5 => 'maí',
+		6 => 'júní',
+		7 => 'júlí',
+		8 => 'ágúst',
+		9 => 'september',
+		10 => 'október',
+		11 => 'nóvember',
+		12 => 'desember',
+	];
+
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
+	{
+		return match ($char) {
+			'D' => self::DAYS_SHORT[$dateTime->format('N')],
+			'l' => self::DAYS_LONG[$dateTime->format('N')],
+			'M' => self::MONTHS_SHORT[$dateTime->format('n')],
+			'F' => self::MONTHS_LONG[$dateTime->format('n')],
+			default => null,
+		};
+	}
+
+	public function resolveFormat(string $format): ?string
+	{
+		return match($format) {
+			'LT' => 'H:i',
+			'LTS' => 'H:i:s',
+			'L' => 'd.m.Y',
+			'LL' => 'j. F Y',
+			'LLL' => 'j. F [kl.] H:i',
+			'LLLL' => 'l j. F Y [kl.] H:i',
+			default => null,
+		};
+	}
+}

--- a/src/Locales/SvSe.php
+++ b/src/Locales/SvSe.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus\Locales;
+
+use Sunkan\Dictus\LocaleFormat;
+
+final class SvSe implements LocaleFormat
+{
+	private const MONTHS_SHORT = [
+		1 => 'Jan',
+		2 => 'Feb',
+		3 => 'Mar',
+		4 => 'Apr',
+		5 => 'Maj',
+		6 => 'Jun',
+		7 => 'Jul',
+		8 => 'Aug',
+		9 => 'Sep',
+		10 => 'Okt',
+		11 => 'Nov',
+		12 => 'Dec',
+	];
+
+	private const MONTHS_LONG = [
+		1 => 'Januari',
+		2 => 'Februari',
+		3 => 'Mars',
+		4 => 'April',
+		5 => 'Maj',
+		6 => 'Juni',
+		7 => 'Juli',
+		8 => 'Augusti',
+		9 => 'September',
+		10 => 'Oktober',
+		11 => 'November',
+		12 => 'December',
+	];
+
+	private const DAYS_SHORT = [
+		1 => 'mån',
+		2 => 'tis',
+		3 => 'ons',
+		4 => 'tor',
+		5 => 'fre',
+		6 => 'lör',
+		7 => 'sön',
+	];
+
+	private const DAYS_LONG = [
+		1 => 'Måndag',
+		2 => 'Tisdag',
+		3 => 'Onsdag',
+		4 => 'Torsdag',
+		5 => 'Fredag',
+		6 => 'Lördag',
+		7 => 'Söndag',
+	];
+
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
+	{
+		return match ($char) {
+			'D' => self::DAYS_SHORT[$dateTime->format('N')],
+			'l' => self::DAYS_LONG[$dateTime->format('N')],
+			'M' => self::MONTHS_SHORT[$dateTime->format('n')],
+			'F' => self::MONTHS_LONG[$dateTime->format('n')],
+			default => null,
+		};
+	}
+
+	public function resolveFormat(string $format): ?string
+	{
+		return match($format) {
+			'LT' => 'H:i',
+			'LTS' => 'H:i:s',
+			'L' => 'd.m.Y',
+			'LL' => 'j F Y',
+			'LLL' => 'j F [kl.] H:i',
+			'LLLL' => 'l j F Y [kl.] H:i',
+			default => null,
+		};
+	}
+}

--- a/src/LocalizedFormat.php
+++ b/src/LocalizedFormat.php
@@ -3,7 +3,7 @@
 namespace Sunkan\Dictus;
 
 /**
- * @deprecated Use your own constants for local formats
+ * @deprecated Use your own constants for locale formats
  */
 interface LocalizedFormat
 {

--- a/src/LocalizedFormatter.php
+++ b/src/LocalizedFormatter.php
@@ -4,5 +4,5 @@ namespace Sunkan\Dictus;
 
 interface LocalizedFormatter extends Formatter
 {
-	public function setLocal(string $local): void;
+	public function setLocale(string $locale): void;
 }

--- a/src/LocalizedStrftimeFormatter.php
+++ b/src/LocalizedStrftimeFormatter.php
@@ -19,13 +19,13 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 	private static array $intlCache = [];
 
 	public function __construct(
-		private string $local,
+		private string $locale,
 		private string $format,
 	) {}
 
-	public function setLocal(string $local): void
+	public function setLocale(string $local): void
 	{
-		$this->local = $local;
+		$this->locale = $local;
 	}
 
 	public function setFormat(string $format): void
@@ -36,7 +36,7 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 	public function format(\DateTimeInterface $date): string
 	{
 		$date = DateTimeImmutable::createFromInterface($date);
-		return $this->strftime($this->format, $date, $this->local);
+		return $this->strftime($this->format, $date, $this->locale);
 	}
 
 	private function strftime(string $format, DateTimeImmutable $timestamp, string $local): string

--- a/tests/LocalizedDateTimeFormatterTest.php
+++ b/tests/LocalizedDateTimeFormatterTest.php
@@ -8,10 +8,21 @@ final class LocalizedDateTimeFormatterTest extends TestCase
 {
 	public function testReadableFormat(): void
 	{
-		$formatter = new LocalizedDateTimeFormatter('is_IS', 'l d. F [kl.] H:i');
+		LocalizedDateTimeFormatter::addLocaleFormat('is_IS', new \Sunkan\Dictus\Locales\IsIs());
+		$formatter = new LocalizedDateTimeFormatter('is_IS', 'l LLL \T\e\s\t');
 
 		$date = new DateTimeImmutable('2023-08-21 16:26:14');
 
-		$this->assertSame('mánudagur 21. ágúst kl. 16:26', $formatter->format($date));
+		$this->assertSame('mánudagur 21. ágúst kl. 16:26 Test', $formatter->format($date));
+	}
+
+	public function testEnglishFormat(): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat('en_GB', new \Sunkan\Dictus\Locales\EnGb());
+		$formatter = new LocalizedDateTimeFormatter('en_GB', 'l LLL \T\e\s\t');
+
+		$date = new DateTimeImmutable('2023-08-21 16:26:14');
+
+		$this->assertSame('Monday 21 August 16:26 Test', $formatter->format($date));
 	}
 }


### PR DESCRIPTION
We don't want to use the intl extension since it's slow and it changes
randomly without any forewarning.

Add new interface for defining LocaleFormat
Refactor all code that used IntlDateFormatter and replaced it 
with LocalsFormat
