### PR TITLE
Make localized DateTime formatter comparable with IntlDateFormatter

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,10 +21,11 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 experimental:
                     - false
                 include:
-                    - php-version: "8.5"
+                    - php-version: "8.6"
                       composer-options: "--ignore-platform-reqs"
                       experimental: true
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,14 @@
-<phpunit bootstrap="./vendor/autoload.php">
-    <testsuites>
-        <testsuite name="event-dispatcher">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+	<coverage processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">./src</directory>
+		</include>
+	</coverage>
+	<testsuites>
+		<testsuite name="event-dispatcher">
+			<directory>./tests</directory>
+		</testsuite>
+	</testsuites>
 </phpunit>

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Sunkan\Dictus;
 
-final class DateTimeFormatter implements Formatter, MutableFormatter
+final class DateTimeFormatter implements FormatterDateTime, MutableFormatter
 {
 	public function __construct(
 		private string $format,
@@ -16,6 +16,11 @@ final class DateTimeFormatter implements Formatter, MutableFormatter
 	public function setFormat(string $format): void
 	{
 		$this->format = $format;
+	}
+
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	{
+		return $timestamp->format($format);
 	}
 
 	public function formatDate(string $format, \DateTimeInterface $date): string

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -18,8 +18,8 @@ final class DateTimeFormatter implements Formatter, MutableFormatter
 		$this->format = $format;
 	}
 
-	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	public function formatDate(string $format, \DateTimeInterface $date): string
 	{
-		return $timestamp->format($format);
+		return $date->format($format);
 	}
 }

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -17,4 +17,9 @@ final class DateTimeFormatter implements Formatter, MutableFormatter
 	{
 		$this->format = $format;
 	}
+
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	{
+		return $timestamp->format($format);
+	}
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -5,4 +5,6 @@ namespace Sunkan\Dictus;
 interface Formatter
 {
 	public function format(\DateTimeInterface $date): string;
+
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string;
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -6,5 +6,5 @@ interface Formatter
 {
 	public function format(\DateTimeInterface $date): string;
 
-	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string;
+	public function formatDate(string $format, \DateTimeInterface $date): string;
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -6,5 +6,8 @@ interface Formatter
 {
 	public function format(\DateTimeInterface $date): string;
 
-	public function formatDate(string $format, \DateTimeInterface $date): string;
+	/**
+	 * @deprecated use FormatterDateTime::formatDate
+	 */
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string;
 }

--- a/src/FormatterDateTime.php
+++ b/src/FormatterDateTime.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus;
+
+interface FormatterDateTime extends Formatter
+{
+	public function formatDate(string $format, \DateTimeInterface $date): string;
+}

--- a/src/Locales/EnGb.php
+++ b/src/Locales/EnGb.php
@@ -8,19 +8,25 @@ final class EnGb implements LocaleFormat
 {
 	public function resolveFormat(string $format): ?string
 	{
-		return match($format) {
+		return match ($format) {
 			'LT' => 'H:i',
 			'LTS' => 'H:i:s',
 			'L' => 'd/m/Y',
 			'LL' => 'j F Y',
-			'LLL' => 'j F H:i',
-			'LLLL' => 'l, j F Y H:i',
+			'll' => 'j M Y',
+			'LLL' => 'j F Y [at] H:i',
+			'lll' => 'j M Y, H:i',
+			'LLLL' => 'l, j F Y [at] H:i',
+			'llll' => 'D, j M Y, H:i',
 			default => null,
 		};
 	}
 
 	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
 	{
+		if ($char === 'M' && $dateTime->format('n') === '9') {
+			return 'Sept';
+		}
 		return null;
 	}
 }

--- a/src/Locales/EnUs.php
+++ b/src/Locales/EnUs.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Sunkan\Dictus\Locales;
+
+use Sunkan\Dictus\LocaleFormat;
+
+final class EnUs implements LocaleFormat
+{
+	public function resolveFormat(string $format): ?string
+	{
+		return match($format) {
+			'LT' => 'g:i A',
+			'LTS' => 'g:i:s A',
+			'L' => 'n/j/y',
+			'LL' => 'F j, Y',
+			'll' => 'M j, Y',
+			'LLL' => 'F j, Y [at] g:i A',
+			'lll' => 'M j, Y, g:i A',
+			'LLLL' => 'l, F j, Y [at] g:i A',
+			'llll' => 'D, M j, Y, g:i A',
+			default => null,
+		};
+	}
+
+	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
+	{
+		return null;
+	}
+}

--- a/src/Locales/IsIs.php
+++ b/src/Locales/IsIs.php
@@ -7,13 +7,13 @@ use Sunkan\Dictus\LocaleFormat;
 final class IsIs implements LocaleFormat
 {
 	private const DAYS_SHORT = [
-		1 => 'mán',
-		2 => 'þri',
-		3 => 'mið',
-		4 => 'fim',
-		5 => 'fös',
-		6 => 'lau',
-		7 => 'sun',
+		1 => 'mán.',
+		2 => 'þri.',
+		3 => 'mið.',
+		4 => 'fim.',
+		5 => 'fös.',
+		6 => 'lau.',
+		7 => 'sun.',
 	];
 
 	private const DAYS_LONG = [
@@ -27,18 +27,18 @@ final class IsIs implements LocaleFormat
 	];
 
 	private const MONTHS_SHORT = [
-		1 => 'jan',
-		2 => 'feb',
-		3 => 'mar',
-		4 => 'apr',
+		1 => 'jan.',
+		2 => 'feb.',
+		3 => 'mar.',
+		4 => 'apr.',
 		5 => 'maí',
-		6 => 'jún',
-		7 => 'júl',
-		8 => 'ágú',
-		9 => 'sep',
-		10 => 'okt',
-		11 => 'nóv',
-		12 => 'des',
+		6 => 'jún.',
+		7 => 'júl.',
+		8 => 'ágú.',
+		9 => 'sep.',
+		10 => 'okt.',
+		11 => 'nóv.',
+		12 => 'des.',
 	];
 
 	private const MONTHS_LONG = [
@@ -72,10 +72,13 @@ final class IsIs implements LocaleFormat
 		return match($format) {
 			'LT' => 'H:i',
 			'LTS' => 'H:i:s',
-			'L' => 'd.m.Y',
+			'L' => 'j.n.Y',
 			'LL' => 'j. F Y',
-			'LLL' => 'j. F [kl.] H:i',
-			'LLLL' => 'l j. F Y [kl.] H:i',
+			'll' => 'j. M Y',
+			'LLL' => 'j. F Y [kl.] H:i',
+			'lll' => 'j. M Y, H:i',
+			'LLLL' => 'l, j. F Y [kl.] H:i',
+			'llll' => 'D j. M Y, H:i',
 			default => null,
 		};
 	}

--- a/src/Locales/SvSe.php
+++ b/src/Locales/SvSe.php
@@ -7,53 +7,53 @@ use Sunkan\Dictus\LocaleFormat;
 final class SvSe implements LocaleFormat
 {
 	private const MONTHS_SHORT = [
-		1 => 'Jan',
-		2 => 'Feb',
-		3 => 'Mar',
-		4 => 'Apr',
-		5 => 'Maj',
-		6 => 'Jun',
-		7 => 'Jul',
-		8 => 'Aug',
-		9 => 'Sep',
-		10 => 'Okt',
-		11 => 'Nov',
-		12 => 'Dec',
+		1 => 'jan.',
+		2 => 'feb.',
+		3 => 'mars',
+		4 => 'apr.',
+		5 => 'maj',
+		6 => 'juni',
+		7 => 'juli',
+		8 => 'aug.',
+		9 => 'sep.',
+		10 => 'okt.',
+		11 => 'nov.',
+		12 => 'dec.',
 	];
 
 	private const MONTHS_LONG = [
-		1 => 'Januari',
-		2 => 'Februari',
-		3 => 'Mars',
-		4 => 'April',
-		5 => 'Maj',
-		6 => 'Juni',
-		7 => 'Juli',
-		8 => 'Augusti',
-		9 => 'September',
-		10 => 'Oktober',
-		11 => 'November',
-		12 => 'December',
+		1 => 'januari',
+		2 => 'februari',
+		3 => 'mars',
+		4 => 'april',
+		5 => 'maj',
+		6 => 'juni',
+		7 => 'juli',
+		8 => 'augusti',
+		9 => 'september',
+		10 => 'oktober',
+		11 => 'november',
+		12 => 'december',
 	];
 
 	private const DAYS_SHORT = [
 		1 => 'mån',
 		2 => 'tis',
 		3 => 'ons',
-		4 => 'tor',
+		4 => 'tors',
 		5 => 'fre',
 		6 => 'lör',
 		7 => 'sön',
 	];
 
 	private const DAYS_LONG = [
-		1 => 'Måndag',
-		2 => 'Tisdag',
-		3 => 'Onsdag',
-		4 => 'Torsdag',
-		5 => 'Fredag',
-		6 => 'Lördag',
-		7 => 'Söndag',
+		1 => 'måndag',
+		2 => 'tisdag',
+		3 => 'onsdag',
+		4 => 'torsdag',
+		5 => 'fredag',
+		6 => 'lördag',
+		7 => 'söndag',
 	];
 
 	public function formatChar(string $char, \DateTimeImmutable $dateTime): ?string
@@ -72,10 +72,13 @@ final class SvSe implements LocaleFormat
 		return match($format) {
 			'LT' => 'H:i',
 			'LTS' => 'H:i:s',
-			'L' => 'd.m.Y',
+			'L' => 'Y-m-d',
 			'LL' => 'j F Y',
-			'LLL' => 'j F [kl.] H:i',
+			'll' => 'j M Y',
+			'LLL' => 'j F Y [kl.] H:i',
+			'lll' => 'j M Y H:i',
 			'LLLL' => 'l j F Y [kl.] H:i',
+			'llll' => 'D j M Y H:i',
 			default => null,
 		};
 	}

--- a/src/LocalizedDateTimeFormatter.php
+++ b/src/LocalizedDateTimeFormatter.php
@@ -2,7 +2,7 @@
 
 namespace Sunkan\Dictus;
 
-final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFormatter
+final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFormatter, FormatterDateTime
 {
 	private const LOCALIZED_SHORT_FORMATS = [
 		// Sorting this list correctly is important because of how we replace from it
@@ -47,6 +47,11 @@ final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFor
 	public function format(\DateTimeInterface $date): string
 	{
 		return $this->formatDate($this->format, $date);
+	}
+
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	{
+		return $this->formatDate($format, $timestamp);
 	}
 
 	public function formatDate(string $format, \DateTimeInterface $date): string

--- a/src/LocalizedDateTimeFormatter.php
+++ b/src/LocalizedDateTimeFormatter.php
@@ -4,6 +4,18 @@ namespace Sunkan\Dictus;
 
 final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFormatter
 {
+	private const LOCALIZED_SHORT_FORMATS = [
+		// Sorting this list correctly is important because of how we replace from it
+		'LTS',
+		'LT',
+		'LLLL',
+		'llll',
+		'LLL',
+		'lll',
+		'LL',
+		'll',
+		'L',
+	];
 	/** @var array<string, LocaleFormat> */
 	private static array $localFormats = [];
 
@@ -34,11 +46,21 @@ final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFor
 
 	public function format(\DateTimeInterface $date): string
 	{
-		return $this->formatTimestamp($this->format, \DateTimeImmutable::createFromInterface($date), $this->locale);
+		return $this->formatTimestamp($this->format, \DateTimeImmutable::createFromInterface($date));
 	}
 
-	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp, string $locale): string
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
 	{
+		foreach (self::LOCALIZED_SHORT_FORMATS as $localizedFormat) {
+			if (!str_contains($format, $localizedFormat)) {
+				continue;
+			}
+			$tmpFormat = $this->localeFormat->resolveFormat($localizedFormat);
+			if ($tmpFormat !== null) {
+				$format = str_replace($localizedFormat, $tmpFormat, $format);
+			}
+		}
+
 		$result = '';
 		$length = mb_strlen($format);
 		$inEscaped = false;
@@ -70,22 +92,8 @@ final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFor
 				continue;
 			}
 			$localResult = $this->localeFormat->formatChar($char, $timestamp);
-			if ($localResult)  {
+			if ($localResult) {
 				$result .= $localResult;
-				continue;
-			}
-
-			$input = mb_substr($format, $i);
-			if ($char === 'L' && preg_match('/^(LTS|LT|L{1,4})/', $input, $match)) {
-				$code = $match[0];
-				$newFormat = $this->localeFormat->resolveFormat($code);
-				if ($newFormat) {
-					$result .= $this->formatTimestamp($newFormat, $timestamp, $locale);
-				}
-				else {
-					$result .= $code;
-				}
-				$i += mb_strlen($code) - 1;
 				continue;
 			}
 

--- a/src/LocalizedDateTimeFormatter.php
+++ b/src/LocalizedDateTimeFormatter.php
@@ -46,11 +46,12 @@ final class LocalizedDateTimeFormatter implements LocalizedFormatter, MutableFor
 
 	public function format(\DateTimeInterface $date): string
 	{
-		return $this->formatTimestamp($this->format, \DateTimeImmutable::createFromInterface($date));
+		return $this->formatDate($this->format, $date);
 	}
 
-	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	public function formatDate(string $format, \DateTimeInterface $date): string
 	{
+		$timestamp = \DateTimeImmutable::createFromInterface($date);
 		foreach (self::LOCALIZED_SHORT_FORMATS as $localizedFormat) {
 			if (!str_contains($format, $localizedFormat)) {
 				continue;

--- a/src/LocalizedStrftimeFormatter.php
+++ b/src/LocalizedStrftimeFormatter.php
@@ -39,6 +39,12 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 		return $this->strftime($this->format, $date, $this->locale);
 	}
 
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	{
+		$date = DateTimeImmutable::createFromInterface($timestamp);
+		return $this->strftime($format, $date, $this->locale);
+	}
+
 	private function strftime(string $format, DateTimeImmutable $timestamp, string $local): string
 	{
 		// remove trailing part not supported by ext-intl locale

--- a/src/LocalizedStrftimeFormatter.php
+++ b/src/LocalizedStrftimeFormatter.php
@@ -39,10 +39,9 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 		return $this->strftime($this->format, $date, $this->locale);
 	}
 
-	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	public function formatDate(string $format, \DateTimeInterface $date): string
 	{
-		$date = DateTimeImmutable::createFromInterface($timestamp);
-		return $this->strftime($format, $date, $this->locale);
+		return $this->strftime($format, DateTimeImmutable::createFromInterface($date), $this->locale);
 	}
 
 	private function strftime(string $format, DateTimeImmutable $timestamp, string $local): string

--- a/src/LocalizedStrftimeFormatter.php
+++ b/src/LocalizedStrftimeFormatter.php
@@ -5,7 +5,7 @@ namespace Sunkan\Dictus;
 use DateTimeImmutable;
 use IntlDateFormatter;
 
-final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFormatter
+final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFormatter, FormatterDateTime
 {
 	private const INTL_FORMATS = [
 		'%a' => 'EEE',    // An abbreviated textual representation of the day	Sun through Sat
@@ -37,6 +37,11 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 	{
 		$date = DateTimeImmutable::createFromInterface($date);
 		return $this->strftime($this->format, $date, $this->locale);
+	}
+
+	public function formatTimestamp(string $format, \DateTimeImmutable $timestamp): string
+	{
+		return $this->strftime($format, $timestamp, $this->locale);
 	}
 
 	public function formatDate(string $format, \DateTimeInterface $date): string

--- a/src/LocalizedStrftimeFormatter.php
+++ b/src/LocalizedStrftimeFormatter.php
@@ -23,9 +23,9 @@ final class LocalizedStrftimeFormatter implements LocalizedFormatter, MutableFor
 		private string $format,
 	) {}
 
-	public function setLocale(string $local): void
+	public function setLocale(string $locale): void
 	{
-		$this->locale = $local;
+		$this->locale = $locale;
 	}
 
 	public function setFormat(string $format): void

--- a/tests/IntlComparisonTest.php
+++ b/tests/IntlComparisonTest.php
@@ -88,6 +88,12 @@ final class IntlComparisonTest extends TestCase
 		return $ret;
 	}
 
+	public static function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+		self::checkIcuDataVersion();
+	}
+
 	/**
 	 * @dataProvider provideMonths
 	 */
@@ -211,6 +217,26 @@ final class IntlComparisonTest extends TestCase
 				(string)$intlFormatter->format($date),
 				$formatter->format($date),
 			);
+		}
+	}
+
+	private static function checkIcuDataVersion(): void
+	{
+		try {
+			$reflector = new \ReflectionExtension('intl');
+			ob_start();
+			$reflector->info();
+			$output = strip_tags((string)ob_get_clean());
+			preg_match('/^ICU Data version (?:=>)?(.*)$/m', $output, $matches);
+			$icuDataVersion = trim($matches[1]);
+		} catch (\ReflectionException) {
+			$icuDataVersion = '';
+		}
+		if ((int)$icuDataVersion < 76) {
+			self::markTestSkipped(sprintf(
+				'Intl comparison tests expect ICU Data version to be at least 76. Current is %s',
+				$icuDataVersion,
+			));
 		}
 	}
 

--- a/tests/IntlComparisonTest.php
+++ b/tests/IntlComparisonTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Sunkan\Dictus\LocaleFormat;
+use Sunkan\Dictus\Locales\EnGb;
+use Sunkan\Dictus\Locales\EnUs;
+use Sunkan\Dictus\Locales\IsIs;
+use Sunkan\Dictus\Locales\SvSe;
+use Sunkan\Dictus\LocalizedDateTimeFormatter;
+
+/**
+ * https://www.php.net/manual/en/datetime.format.php
+ * https://www.php.net/manual/en/intldateformatter.setpattern.php
+ * https://unicode-org.github.io/icu/userguide/format_parse/datetime/
+ * https://github.com/unicode-org/cldr-json
+ * https://momentjs.com/
+ */
+final class IntlComparisonTest extends TestCase
+{
+	private const INTL_FORMAT_MAP = [
+		'LT' => [IntlDateFormatter::NONE, IntlDateFormatter::SHORT],
+		'LTS' => [IntlDateFormatter::NONE, IntlDateFormatter::MEDIUM],
+		'L' => [IntlDateFormatter::SHORT, IntlDateFormatter::NONE],
+		'LL' => [IntlDateFormatter::LONG, IntlDateFormatter::NONE],
+		'll' => [IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE],
+		'LLL' => [IntlDateFormatter::LONG, IntlDateFormatter::SHORT],
+		'lll' => [IntlDateFormatter::MEDIUM, IntlDateFormatter::SHORT],
+		'LLLL' => [IntlDateFormatter::FULL, IntlDateFormatter::SHORT],
+		// This is not available via intl formats without setting a pattern
+		// 'llll' => [],
+	];
+
+	/**
+	 * @return array<string, array{string, LocaleFormat}>
+	 */
+	public static function provideLocales(): array
+	{
+		return [
+			'en' => ['en_US', new EnUs()],
+			'uk' => ['en_GB', new EnGb()],
+			'is' => ['is_IS', new IsIs()],
+			'se' => ['sv_SE', new SvSe()],
+		];
+	}
+
+	/**
+	 * @return array<string, array{string, LocaleFormat, int}>
+	 */
+	public static function provideMonths(): array
+	{
+		$ret = [];
+		foreach (self::provideLocales() as $key => $args) {
+			for ($month = 1; $month <= 12; $month++) {
+				$args[2] = $month;
+				$ret["$key-$month"] = $args;
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * @return array<string, array{string, LocaleFormat, int}>
+	 */
+	public static function provideWeekdays(): array
+	{
+		$ret = [];
+		foreach (self::provideLocales() as $key => $args) {
+			for ($wd = 1; $wd <= 7; $wd++) {
+				$args[2] = $wd;
+				$ret["$key-$wd"] = $args;
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * @return array<string, array{string, LocaleFormat, string}>
+	 */
+	public static function provideFormats(): array
+	{
+		$ret = [];
+		foreach (self::provideLocales() as $key => $args) {
+			foreach (array_keys(self::INTL_FORMAT_MAP) as $k) {
+				$args[2] = $k;
+				$ret["$key-$k"] = $args;
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * @dataProvider provideMonths
+	 */
+	public function testFullMonth(string $locale, LocaleFormat $localeFormat, int $month): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, 'F');
+		$intlFormatter = new IntlDateFormatter($locale, IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, 'MMMM');
+
+		$m = $this->pad($month);
+		$date = new DateTimeImmutable("2023-$m-03 11:11:11");
+
+		$this->assertSame(
+			$intlFormatter->format($date),
+			$formatter->format($date),
+		);
+	}
+
+	/**
+	 * @dataProvider provideMonths
+	 */
+	public function testAbbrMonth(string $locale, LocaleFormat $localeFormat, int $month): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, 'M');
+		$intlFormatter = new IntlDateFormatter($locale, IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, 'MMM');
+
+		$m = $this->pad($month);
+		$date = new DateTimeImmutable("2023-$m-03 11:11:11");
+
+		$this->assertSame(
+			$intlFormatter->format($date),
+			$formatter->format($date),
+		);
+	}
+
+	/**
+	 * @dataProvider provideWeekdays
+	 */
+	public function testFullWeekday(string $locale, LocaleFormat $localeFormat, int $weekday): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, 'l');
+		$intlFormatter = new IntlDateFormatter($locale, IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, 'EEEE');
+
+		$w = $this->pad($weekday);
+		$date = new DateTimeImmutable("2025-12-$w 11:11:11");
+
+		$this->assertSame(
+			$intlFormatter->format($date),
+			$formatter->format($date),
+		);
+	}
+
+	/**
+	 * @dataProvider provideWeekdays
+	 */
+	public function testAbbrWeekday(string $locale, LocaleFormat $localeFormat, int $weekday): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, 'D');
+		$intlFormatter = new IntlDateFormatter($locale, IntlDateFormatter::LONG, IntlDateFormatter::SHORT, null, null, 'EEE');
+
+		$w = $this->pad($weekday);
+		$date = new DateTimeImmutable("2025-12-$w 11:11:11");
+
+		$this->assertSame(
+			$intlFormatter->format($date),
+			$formatter->format($date),
+		);
+	}
+
+	/**
+	 * @dataProvider provideFormats
+	 */
+	public function testFormats(string $locale, LocaleFormat $localeFormat, string $format): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, $format);
+		[$dateType, $timeType] = self::INTL_FORMAT_MAP[$format];
+
+		$intlFormatter = new IntlDateFormatter(
+			$locale,
+			$dateType,
+			$timeType,
+		);
+
+		foreach ($this->createDates() as $date) {
+			$this->assertSame(
+				$intlFormatter->format($date),
+				$formatter->format($date),
+			);
+		}
+	}
+
+	/**
+	 * @dataProvider provideLocales
+	 */
+	public function testSpecialLocalFormat(string $locale, LocaleFormat $localeFormat): void
+	{
+		LocalizedDateTimeFormatter::addLocaleFormat($locale, $localeFormat);
+		$formatter = new LocalizedDateTimeFormatter($locale, 'llll');
+
+		$intlFormatter = new IntlDateFormatter(
+			$locale,
+			IntlDateFormatter::MEDIUM,
+			IntlDateFormatter::SHORT,
+		);
+
+		$dates = $this->createDates();
+		foreach ($dates as $date) {
+			// This should just contain the same as "lll"
+			$this->assertStringContainsString(
+				(string)$intlFormatter->format($date),
+				$formatter->format($date),
+			);
+		}
+		$intlFormatter->setPattern('eee');
+		foreach ($dates as $date) {
+			$this->assertStringContainsString(
+				(string)$intlFormatter->format($date),
+				$formatter->format($date),
+			);
+		}
+	}
+
+	/**
+	 * @return list<DateTimeImmutable>
+	 */
+	private function createDates(): array
+	{
+		$date = new DateTimeImmutable('2025-01-03 09:11:11');
+		$dates = [
+			$date,
+			$date->add(new \DateInterval('PT12H')),
+		];
+
+		for ($i = 1; $i <= 7; $i++) {
+			$dates[] = $date = $date->add(new \DateInterval('P1D'));
+		}
+		for ($i = 1; $i <= 12; $i++) {
+			$dates[] = $date = $date->add(new \DateInterval('P1M'));
+		}
+		return $dates;
+	}
+
+	private function pad(int $month): string
+	{
+		return str_pad((string)$month, 2, '0', STR_PAD_LEFT);
+	}
+}

--- a/tests/LocalizedDateTimeFormatterTest.php
+++ b/tests/LocalizedDateTimeFormatterTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-use Sunkan\Dictus\DateTimeFormat;
 use Sunkan\Dictus\LocalizedDateTimeFormatter;
 
 final class LocalizedDateTimeFormatterTest extends TestCase
@@ -13,7 +12,7 @@ final class LocalizedDateTimeFormatterTest extends TestCase
 
 		$date = new DateTimeImmutable('2023-08-21 16:26:14');
 
-		$this->assertSame('mánudagur 21. ágúst kl. 16:26 Test', $formatter->format($date));
+		$this->assertSame('mánudagur 21. ágúst 2023 kl. 16:26 Test', $formatter->format($date));
 	}
 
 	public function testEnglishFormat(): void
@@ -23,6 +22,6 @@ final class LocalizedDateTimeFormatterTest extends TestCase
 
 		$date = new DateTimeImmutable('2023-08-21 16:26:14');
 
-		$this->assertSame('Monday 21 August 16:26 Test', $formatter->format($date));
+		$this->assertSame('Monday 21 August 2023 at 16:26 Test', $formatter->format($date));
 	}
 }


### PR DESCRIPTION
Change localized DT formatter to be comparable with IntlDateFormatter.

Because the intl extension with the IntlDateFormatter is extremely slow, we have this class.

But until now, we were not quite comparable with the actual output of the intl formatter.

So, here we at least try to be comparable, and have tests to prove so.

Note that this should be a breaking change and result in a 3.x version.
